### PR TITLE
fix: fusion reactor equipment is now a fission reactor

### DIFF
--- a/qsd/constants.lua
+++ b/qsd/constants.lua
@@ -93,7 +93,7 @@ CHARACTER_GEAR = {
         },
     },
     [UNPOWERED_KEY] = {
-        ["fusion-reactor-equipment"] = {
+        ["fission-reactor-equipment"] = {
             {0, 6},
             {4, 6},
         },
@@ -122,7 +122,7 @@ SPIDER_GEAR = {
         },
     },
     [UNPOWERED_KEY] = {
-        ["fusion-reactor-equipment"] = {
+        ["fission-reactor-equipment"] = {
             {0, 0},
             {4, 0},
         },


### PR DESCRIPTION
As seen in the wiki : https://wiki.factorio.com/Portable_fission_reactor

Internal name of the reactor equipment is now "fission-reactor-equipment" 